### PR TITLE
Remove unused shaders from Renderer.cs

### DIFF
--- a/Shuriken/Rendering/Renderer.cs
+++ b/Shuriken/Rendering/Renderer.cs
@@ -44,9 +44,7 @@ namespace Shuriken.Rendering
             shaderDictionary = new Dictionary<string, ShaderProgram>();
 
             ShaderProgram basicShader = new ShaderProgram("basic", Path.Combine(shadersDir, "basic.vert"), Path.Combine(shadersDir, "basic.frag"));
-            ShaderProgram boxShader = new ShaderProgram("box", Path.Combine(shadersDir, "bb.vert"), Path.Combine(shadersDir, "bb.frag"));
             shaderDictionary.Add(basicShader.Name, basicShader);
-            shaderDictionary.Add(boxShader.Name, boxShader);
 
             // setup vertex indices
             indices = new uint[MaxIndices];


### PR DESCRIPTION
The `bb` shader was stopping Shuriken from booting successfully, and removing it doesn't seem to cause any issues.