### PR TITLE
Add colour value editor to animations

### DIFF
--- a/Shuriken/Controls/AnimationTimeline.xaml
+++ b/Shuriken/Controls/AnimationTimeline.xaml
@@ -156,7 +156,8 @@
                         <Label>Frame</Label>
                         <TextBox Text="{Binding SelectedKey.Frame}" IsEnabled="{Binding KeySelected, UpdateSourceTrigger=PropertyChanged}"/>
                         <Label>Value</Label>
-                        <TextBox Text="{Binding SelectedKey.KValue}" IsEnabled="{Binding KeySelected, UpdateSourceTrigger=PropertyChanged}"/>
+                        <TextBox Name="FrameValueText" Text="{Binding SelectedKey.KValue}" IsEnabled="{Binding KeySelected, UpdateSourceTrigger=PropertyChanged}" />
+                        <local:ColorControl x:Name="FrameValueColor" Value="{Binding SelectedKey.KValueColor, Mode=TwoWay}" IsEnabled="{Binding KeySelected, UpdateSourceTrigger=PropertyChanged}"/>
                     </StackPanel>
                 </ScrollViewer>
             </GroupBox>

--- a/Shuriken/Controls/AnimationTimeline.xaml.cs
+++ b/Shuriken/Controls/AnimationTimeline.xaml.cs
@@ -106,7 +106,22 @@ namespace Shuriken.Controls
             MaxValue = 100;
             holdingKey = false;
 
+            UpdateValueEditor();
             DrawTimeline();
+        }
+
+        private void UpdateValueEditor()
+        {
+            if (track != null && track.Type.IsColor())
+            {
+                FrameValueColor.Visibility = Visibility.Visible;
+                FrameValueText.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                FrameValueColor.Visibility = Visibility.Collapsed;
+                FrameValueText.Visibility = Visibility.Visible;
+            }
         }
 
         private Line GetFrameLine(int frame)
@@ -330,6 +345,7 @@ namespace Shuriken.Controls
             }
 
             ScanKeyframe();
+            UpdateValueEditor();
             DrawTimeline();
         }
 

--- a/Shuriken/Models/Animation/AnimationType.cs
+++ b/Shuriken/Models/Animation/AnimationType.cs
@@ -22,4 +22,18 @@ namespace Shuriken.Models.Animation
         GradientTR  = 1024,
         GradientBR  = 2048
     }
+
+    public static class AnimationTypeMethods
+    {
+        public static bool IsColor(this AnimationType type)
+        {
+            return new AnimationType[] { 
+                AnimationType.Color,
+                AnimationType.GradientTL,
+                AnimationType.GradientBL,
+                AnimationType.GradientTR,
+                AnimationType.GradientBR
+            }.Contains(type);
+        }
+    }
 }

--- a/Shuriken/Models/Animation/Keyframe.cs
+++ b/Shuriken/Models/Animation/Keyframe.cs
@@ -29,6 +29,11 @@ namespace Shuriken.Models.Animation
         }
         public bool HasNoFrame { get; set; }
         public float KValue { get; set; }
+        public Color KValueColor
+        {
+            get => new Color(KValue);
+            set => KValue = value.ToUint();
+        }
         public int Field08 { get; set; }
         public float Offset1 { get; set; }
         public float Offset2 { get; set; }


### PR DESCRIPTION
This PR adds a colour value editor for colour based animations, while maintaining a float based editor for the remaining anim types. Looks like this visually:

![image](https://user-images.githubusercontent.com/20132880/161931059-6e6c80aa-d224-4868-8757-fd54c1b0e717.png)
