### PR TITLE
Further animation fixes

### DIFF
--- a/Shuriken/Controls/AnimationTimeline.xaml
+++ b/Shuriken/Controls/AnimationTimeline.xaml
@@ -154,10 +154,10 @@
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <StackPanel>
                         <Label>Frame</Label>
-                        <TextBox Text="{Binding SelectedKey.Frame}" IsEnabled="{Binding KeySelected, UpdateSourceTrigger=PropertyChanged}"/>
+                        <TextBox Text="{Binding SelectedKey.Frame, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding KeySelected}"/>
                         <Label>Value</Label>
-                        <TextBox Name="FrameValueText" Text="{Binding SelectedKey.KValue}" IsEnabled="{Binding KeySelected, UpdateSourceTrigger=PropertyChanged}" />
-                        <local:ColorControl x:Name="FrameValueColor" Value="{Binding SelectedKey.KValueColor, Mode=TwoWay}" IsEnabled="{Binding KeySelected, UpdateSourceTrigger=PropertyChanged}"/>
+                        <TextBox Name="FrameValueText" Text="{Binding SelectedKey.KValue, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding KeySelected}" />
+                        <local:ColorControl x:Name="FrameValueColor" Value="{Binding SelectedKey.KValueColor, Mode=TwoWay}" IsEnabled="{Binding KeySelected}"/>
                     </StackPanel>
                 </ScrollViewer>
             </GroupBox>

--- a/Shuriken/Controls/AnimationTimeline.xaml.cs
+++ b/Shuriken/Controls/AnimationTimeline.xaml.cs
@@ -250,11 +250,11 @@ namespace Shuriken.Controls
 
                     if (k < track.Keyframes.Count - 1)
                     {
-                        Line line = GetCurve(track.Keyframes[k], track.Keyframes[k + 1]);
-                        line.X1 -= c.Width / 2;
-                        line.X2 -= c.Width / 2;
-                        line.Y1 += c.Height / 2;
-                        line.Y2 += c.Height / 2;
+                        //Line line = GetCurve(track.Keyframes[k], track.Keyframes[k + 1]);
+                        //line.X1 -= c.Width / 2;
+                        //line.X2 -= c.Width / 2;
+                        //line.Y1 += c.Height / 2;
+                        //line.Y2 += c.Height / 2;
                         //Timeline.Children.Add(line);
                     }
 

--- a/Shuriken/Controls/AnimationTimeline.xaml.cs
+++ b/Shuriken/Controls/AnimationTimeline.xaml.cs
@@ -56,7 +56,16 @@ namespace Shuriken.Controls
         public Keyframe SelectedKey
         {
             get { return keyframe; }
-            set { keyframe = value;NotifyPropertyChanged("KeySelected"); }
+            set 
+            {
+                keyframe = value; 
+                NotifyPropertyChanged("KeySelected");
+                if (value != null)
+                {
+                    // Regiser for changes in order to update original keyframe value from color
+                    value.KValueColor.PropertyChanged += UpdateKeyframeValueFromColor;
+                }
+            }
         }
 
         public bool KeySelected
@@ -122,6 +131,11 @@ namespace Shuriken.Controls
                 FrameValueColor.Visibility = Visibility.Collapsed;
                 FrameValueText.Visibility = Visibility.Visible;
             }
+        }
+
+        private void UpdateKeyframeValueFromColor(object sender, PropertyChangedEventArgs e)
+        {
+            SelectedKey.KValue = SelectedKey.KValueColor.ToFloat();
         }
 
         private Line GetFrameLine(int frame)

--- a/Shuriken/Models/Animation/Keyframe.cs
+++ b/Shuriken/Models/Animation/Keyframe.cs
@@ -29,11 +29,9 @@ namespace Shuriken.Models.Animation
         }
         public bool HasNoFrame { get; set; }
         public float KValue { get; set; }
-        public Color KValueColor
-        {
-            get => new Color(KValue);
-            set => KValue = value.ToUint();
-        }
+
+        public Color KValueColor { get; set; }
+
         public int Field08 { get; set; }
         public float Offset1 { get; set; }
         public float Offset2 { get; set; }
@@ -44,6 +42,7 @@ namespace Shuriken.Models.Animation
         {
             Frame = 0;
             KValue = 0.0f;
+            KValueColor = new Color();
             Field08 = 0;
             Offset1 = 0.0f;
             Offset2 = 0.0f;
@@ -54,6 +53,7 @@ namespace Shuriken.Models.Animation
         {
             Frame = (int)k.Frame;
             KValue = k.Value;
+            KValueColor = new Color(k.Value);
             Field08 = (int)k.Field08;
             Offset1 = k.Offset1;
             Offset2 = k.Offset2;

--- a/Shuriken/Models/Color.cs
+++ b/Shuriken/Models/Color.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 
 namespace Shuriken.Models
 {
-    public class Color
+    public class Color : INotifyPropertyChanged
     {
         public byte R { get; set; }
         public byte G { get; set; }
@@ -73,6 +73,8 @@ namespace Shuriken.Models
             A = c.A;
         }
 
+        public event PropertyChangedEventHandler PropertyChanged;
+
         public Vector4 ToFloats()
         {
             return new Vector4(R / 255.0f, G / 255.0f, B / 255.0f, A / 255.0f);
@@ -81,6 +83,11 @@ namespace Shuriken.Models
         public uint ToUint()
         {
             return BitConverter.ToUInt32(new byte[] { A, B, G, R });
+        }
+
+        public float ToFloat()
+        {
+            return BitConverter.ToSingle(new byte[] { A, B, G, R });
         }
 
         public override string ToString()

--- a/Shuriken/ViewModels/MainViewModel.cs
+++ b/Shuriken/ViewModels/MainViewModel.cs
@@ -239,6 +239,7 @@ namespace Shuriken.ViewModels
             }
 
             // process group layers
+            Dictionary<int, int> trackIndexPerKey = new Dictionary<int, int>();
             for (int g = 0; g < uiScene.Groups.Count; ++g)
             {
                 for (int c = 0; c < scene.UICastGroups[g].CastCount; ++c)
@@ -326,7 +327,6 @@ namespace Shuriken.ViewModels
 
                 foreach (var entry in entryIndexMap)
                 {
-                    int trackIndex = 0;
                     int trackAnimIndex = 0;
                     XNCPLib.XNCP.Animation.AnimationKeyframeData keyframeData = scene.AnimationKeyframeDataList[entry.Value];
                     for (int c = 0; c < keyframeData.GroupAnimationDataList[g].CastCount; ++c)
@@ -345,9 +345,14 @@ namespace Shuriken.ViewModels
 
                                 if (tracks == null)
                                 {
-                                    tracks = uiScene.Animations[entry.Key].LayerAnimations[trackIndex++].Tracks.ToList();
+                                    if (!trackIndexPerKey.ContainsKey(entry.Key)) {
+                                        trackIndexPerKey.Add(entry.Key, 0);
+                                    }
+
+                                    tracks = uiScene.Animations[entry.Key].LayerAnimations[trackIndexPerKey[entry.Key]++].Tracks.ToList();
                                     trackAnimIndex = 0;
                                 }
+
                                 AnimationTrack anim = tracks[trackAnimIndex++];
 
                                 castAnimData.SubDataList[castAnimDataIndex].Field00 = anim.Field00;

--- a/Shuriken/Views/UIEditor.xaml.cs
+++ b/Shuriken/Views/UIEditor.xaml.cs
@@ -346,7 +346,7 @@ namespace Shuriken.Views
             return new Vec2(x, y);
         }
 
-        private void UpdateCast(UIScene scene, UICast lyr, CastTransform transform, float time)
+        private void UpdateCast(UIScene scene, UICast lyr, CastTransform transform, float time, Vec2 parentOrigin = null)
         {
             int sprID = GetSprite(scene, lyr, time);
 
@@ -372,6 +372,12 @@ namespace Shuriken.Views
 
             if ((lyr.Field34 & (1 << 11)) != 0)
                 scale.Y *= transform.Scale.Y;
+
+            if (parentOrigin != null)
+            {
+                position.X = parentOrigin.X + (position.X - parentOrigin.X) * scale.X;
+                position.Y = parentOrigin.Y + (position.Y - parentOrigin.Y) * scale.Y;
+            }
 
             // inherit color
             if ((lyr.Field34 & 8) != 0)
@@ -407,7 +413,16 @@ namespace Shuriken.Views
                     }
 
                     var childTransform = new CastTransform(position + posAdjust, zPosition, rotation, scale, color);
-                    UpdateCast(scene, child, childTransform, time);
+
+                    // Not correct, blb_gauge looks better when passing position and doesn't have field5c with value 2
+                    if (child.Field5C == 2)
+                    {
+                        UpdateCast(scene, child, childTransform, time, position);
+                    }
+                    else
+                    {
+                        UpdateCast(scene, child, childTransform, time);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Previous PR had issues with the colour values in animations since it wasn't updating the underlying keyframe value. This one does.

This PR also fixes Shuriken crashing whenever selecting some animations. It was trying to create a line for the timeline, but it is never used, so I decided to comment it out to prevent issues.